### PR TITLE
Changes for readr 2.0.0

### DIFF
--- a/R/eyelink_parser.R
+++ b/R/eyelink_parser.R
@@ -179,7 +179,7 @@ process_raw <- function(raw, blocks, info) {
 
     # Process raw sample data using readr
     if (length(raw) == 1) raw <- c(raw, "")
-    raw_df <- read_tsv(raw, col_names = colnames, col_types = coltypes, na = ".", progress = FALSE)
+    raw_df <- read_tsv(I(raw), col_names = colnames, col_types = coltypes, na = ".", progress = FALSE)
     if (info$tracking & !info$cr) {
         raw_df$cr.info <- NULL  # Drop CR column when not actually used
     }

--- a/tests/testthat/test_eyelink_parser.R
+++ b/tests/testthat/test_eyelink_parser.R
@@ -237,24 +237,24 @@ test_that("test_block_parsing", {
     )
 
     # Test handling of no END line
-    a <- read.asc(testfile)
+    a <- read.asc(I(testfile))
     expect_equal(nrow(a$raw), 3)
     expect_equal("TRIAL_ID 1" %in% a$msg$text, TRUE)
 
     # Test handling of END line as last line
     testfile <- c(testfile, "END\t598729\t SAMPLES\t EVENTS\t RES\t 41.91\t 38.82")
-    a <- read.asc(testfile)
+    a <- read.asc(I(testfile))
     expect_equal(nrow(a$raw), 3)
     expect_equal("TRIAL_ID 1" %in% a$msg$text, TRUE)
 
     # Test handling of content after last END line
     testfile <- c(testfile, "MSG\t601379 trialResult 3")
-    a <- read.asc(testfile)
+    a <- read.asc(I(testfile))
     expect_equal(nrow(a$raw), 3)
     expect_equal("TRIAL_ID 1" %in% a$msg$text, TRUE)
 
     # Test handling of content after last END line when parse_all is TRUE
-    a <- read.asc(testfile, parse_all = TRUE)
+    a <- read.asc(I(testfile), parse_all = TRUE)
     expect_equal(nrow(a$raw), 3)
     expect_equal("TRIAL_ID 1" %in% a$msg$text, TRUE)
     expect_equal("trialResult 3" %in% a$msg$text, TRUE)


### PR DESCRIPTION
In readr 2.0.0 the way that literal string data is passed to readr has
changed. Previously any length 2+ character vector was treated as
literal data, now these vectors are treated as multiple file names to be
read into one dataset.

To specify literal data you can use wrap it in `I()`, which is what this
change does.

Without this change the tests will break when readr 2.0.0 is submitted. We expected to submit readr in 3-5 weeks from now.

You will need to make these changes and submit a new version to avoid errors on CRAN.